### PR TITLE
[BOJ] solved 2206

### DIFF
--- a/Baesuyeon_zone/week02/BOJ/BOJ_2206.py
+++ b/Baesuyeon_zone/week02/BOJ/BOJ_2206.py
@@ -1,0 +1,57 @@
+import sys
+input = sys.stdin.readline
+
+from collections import deque
+
+# 상하좌우 방향
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+# BFS 구현
+def bfs(N, M, board):
+    # 벽을 부쉈는지에 대한 상태까지 함께 관리하기 위해 3차원 배열 사용
+    # visited[x][y][0]: 벽 안 부쉈을 때 방문
+    # visited[x][y][1]: 벽 부쉈을 때 방문
+    visited = [[[0]*2 for _ in range(M)] for _ in range(N)]
+    queue = deque()
+    
+    # 시작 노드 : (0, 0)에서 벽 안 부순 상태로 시작
+    queue.append((0, 0, 0))  
+    visited[0][0][0] = 1     # 시작 위치 방문 처리
+
+    while queue:
+        # x, y, 벽 부쉈는지
+        x, y, broken = queue.popleft()
+
+        # 도착지 도달 시 걸린 거리 return
+        if x == N-1 and y == M-1:
+            return visited[x][y][broken]
+
+        # 상하좌우 네 방향으로 탐색 반복
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+
+            # 범위를 벗어나지 않게 체크
+            if 0 <= nx < N and 0 <= ny < M:
+                # 다음 칸이 벽(1)이고, 아직 벽을 부수지 않았을 때(0)
+                if board[nx][ny] == 1 and broken == 0 and visited[nx][ny][1] == 0:
+                    visited[nx][ny][1] = visited[x][y][0] + 1
+                    queue.append((nx, ny, 1))
+
+                # 다음 칸이 벽이 아니고(0), 아직 방문 안 한 경우
+                if board[nx][ny] == 0 and visited[nx][ny][broken] == 0:
+                    visited[nx][ny][broken] = visited[x][y][broken] + 1
+                    queue.append((nx, ny, broken))
+
+    # 도달 불가 시
+    return -1
+
+
+# N, M 입력받기
+N, M = map(int, input().split())
+
+# N X M 사이즈 보드 제작
+board = [list(map(int, input().strip())) for _ in range(N)]
+    
+print(bfs(N, M, board))


### PR DESCRIPTION
## 조건정리

- 칸을 노드로 생각하고 (1,1)에서 도착 지점까지 갈 수 있는 최단 경로를 찾자.
- 벽을 부수고 이동하는 것이 최단경로에 도달하는데 도움이 된다면, 벽은 한 개까지 부술 수 있다.
- 시작 노드의 인접 노드부터 탐색
    - 인접 노드 두 가지 모두 1이면 그 다음 노드가 1이 아닌 노드를 뚫고 지나감
    - 인접 노드 중 하나만 0이면 0인 노드로 넘어가서 인접 노드 탐색
    - 인접 노드 중 1인 노드를 한 번이라도 지났다면, 다음부터는 1인 노드는 절대 못 지나감
        - 노드 방문 여부 외에도 이미 벽을 한 번 부쉈는지, 한 번도 안 부쉈는지에 대한 상태 파악을 해줘야 함. -> 3차원 배열 사용
- 최단 거리까지 걸린 거리 출력
- 불가능할 때는 -1을 출력

## 구현과정

- bfs 알고리즘 구현 및 사용
- 입력받은 N과 M 그리고 각 노드의 0과1 포함 여부를 기반으로 board 작성
- 상하좌우 방향으로 이동 가능하므로 판다 문제처럼 x, y를 기반으로 움직일 수 있도록 dx, dy 방향 좌표를 설정해준다.
    
    ```python
    # 방향 좌표 설정 (상, 하, 좌, 우)
    dx = [-1, 1, 0, 0]
    dy = [0, 0, -1, 1]
    ```
    
- 인접 노드가 0 0, 1 0, 1 1 인 경우에 대해 조건문 작성
    
    ```python
    # 상하좌우 이동
    for i in range(4):
        nx = x + dx[i]
        ny = y + dy[i]
    
        # 범위를 벗어나지 않게 체크
        if 0 <= nx < N and 0 <= ny < M:
            # 다음 칸이 벽(1)이고, 아직 벽을 부수지 않았을 때(0)
            if board[nx][ny] == 1 and broken == 0 and visited[nx][ny][1] == 0:
                visited[nx][ny][1] = visited[x][y][0] + 1
                queue.append((nx, ny, 1))
    
            # 다음 칸이 벽이 아니고(0), 아직 방문 안 한 경우
            if board[nx][ny] == 0 and visited[nx][ny][broken] == 0:
                visited[nx][ny][broken] = visited[x][y][broken] + 1
                queue.append((nx, ny, broken))
    ```