### PR TITLE
[BOJ] 6087

### DIFF
--- a/Baesuyeon_zone/week03/BOJ/BOJ_6087.py
+++ b/Baesuyeon_zone/week03/BOJ/BOJ_6087.py
@@ -1,0 +1,44 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+W, H = map(int, input().split())
+board = [list(input().strip()) for _ in range(H)]
+
+# 시작/도착 위치 구하기
+points = [(i, j) for i in range(H) for j in range(W) if board[i][j] == 'C']
+(start_y, start_x), (end_y, end_x) = points
+
+# 상하좌우 (이전 문제들에서 적용했던 좌표 차원 차용)
+dx = [0, 0, -1, 1]
+dy = [-1, 1, 0, 0]
+
+# 방문 체크: [H][W][4방향]
+visited = [[[float('inf')] * 4 for _ in range(W)] for _ in range(H)]
+
+def dijkstra():
+    heap = []
+    # 시작점에서 4방향으로 출발 (거울 설치 수, y, x, 방향)
+    for d in range(4):
+        heapq.heappush(heap, (0, start_y, start_x, d))
+        visited[start_y][start_x][d] = 0
+
+    while heap:
+        mirror, y, x, dir = heapq.heappop(heap)
+
+        # 도착지에 도달했으면 종료 조건 가능 (최솟값만 필요하면 바로 종료 가능)
+        if (y, x) == (end_y, end_x):
+            return mirror
+
+        for nd in range(4):
+            ny = y + dy[nd]
+            nx = x + dx[nd]
+            # 범위 안, 벽이 아니어야 함
+            if 0 <= ny < H and 0 <= nx < W and board[ny][nx] != '*':
+                # 같은 방향 → 거울 추가 X / 다른 방향 → 거울 +1
+                new_mirror = mirror if dir == nd else mirror + 1
+                if visited[ny][nx][nd] > new_mirror:
+                    visited[ny][nx][nd] = new_mirror
+                    heapq.heappush(heap, (new_mirror, ny, nx, nd))
+
+print(dijkstra())


### PR DESCRIPTION
## 조건 정리
- 지도 크기 : W × H (1 ≤ W, H ≤ 100)
- 요소 : '.': 빈칸, '*': 벽, 'C': 레이저 시작/도착 지점
- 목표 : 두 'C'를 직선 레이저 + 최소 거울로 연결하는 최소 거울 개수 출력
- 이동 : 상하좌우 4방향, 빈칸만 가능
- 방향 전환 : 방향이 바뀔 때마다 거울이 필요함 → 거울 설치 횟수 = 방향 전환 횟수


## 구현 방식
- 다익스트라 + 방향 상태 저장
- 큐에 저장할 정보: (거울 개수, x, y, 방향)
⭐️ _방향 정보까지 함께 저장해야 전환 여부를 판단할 수 있음._
- 방문 체크: visited[y][x][dir]
- 위치 + 방향별로 방문 체크 → 같은 칸이라도 방향이 다르면 처리해야 함.
- 우선순위 큐 사용:heapq로 거울 개수가 적은 경우 우선 탐색..
- 이동 조건
    - 이동한 방향이 같으면 → 거울 추가 X
    - 방향이 달라지면 → 거울 개수 +1